### PR TITLE
install python marker file

### DIFF
--- a/micro-ros_kobuki_demo_remote/setup.py
+++ b/micro-ros_kobuki_demo_remote/setup.py
@@ -23,6 +23,8 @@ setup(
     version='0.0.1',
     packages=find_packages(exclude=['test']),
     data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name + '/config/', ['config/joy.params',
                                                 'config/kobuki.rviz']),


### PR DESCRIPTION
That should fix the Python package registry. See here: https://answers.ros.org/question/332452/issues-building-ros2-dashing-python-package/

Signed-off-by: Knese Karsten (CR/RTC-HMI4) <karsten.knese@us.bosch.com>